### PR TITLE
Top nav bar uses MDAnalysis-like colors rather than default rtd colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The rules for this file:
 
 ### Changed
 <!-- Changes in existing functionality -->
-- Customised to MDAnalysis colours (PR #4, #5, #9)
+- Customised to MDAnalysis colours (PR #4, #5, #9, #13)
 
 ### Deprecated
 <!-- Soon-to-be removed features -->

--- a/mdanalysis_sphinx_theme/sass/mdanalysis-sphinx.scss
+++ b/mdanalysis_sphinx_theme/sass/mdanalysis-sphinx.scss
@@ -1,6 +1,11 @@
 .wy-nav-content-wrap {
     background: #fcfcfc;
 }
+
+.wy-nav-top {
+    background: $readthedocs-dark-gray;
+}
+
 .wy-side-nav-search {
     background-color: $mdanalysis-white;
 


### PR DESCRIPTION
- Added the wy-nav-top class to SASS
  with the mdanalysis gray color