### PR TITLE
Correctly resolve path to the logo and favicon

### DIFF
--- a/mdanalysis_sphinx_theme/layout.html
+++ b/mdanalysis_sphinx_theme/layout.html
@@ -9,7 +9,7 @@
 <head>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/academicons/1.9.1/css/academicons.min.css" integrity="sha512-b1ASx0WHgVFL5ZQhTgiPWX+68KjS38Jk87jg7pe+qC7q9YkEtFq0z7xCglv7qGIs/68d3mAp+StfC8WKC5SSAg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="shortcut icon" href="{{ _favicon_url }}">
+  <link rel="shortcut icon" href="{{ pathto(_favicon_url, 1) }}">
 </head>
 
 {% extends "sphinx_rtd_theme/layout.html" %}
@@ -28,7 +28,7 @@
 {% set _root_doc = root_doc|default(master_doc) %}
 <a href="{{ pathto(_root_doc) }}"{% if not theme_logo_only %} class="icon icon-home"{% endif %}>
   {% if not theme_logo_only %}{{ project }}{% endif %}
-    <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
+    <img src="{{ pathto(_logo_url, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
 </a>
 
 {% if theme_display_version %}


### PR DESCRIPTION
- use `pathto(..., 1)` instead of a raw path for both the favicon and logo in layout.html
- fixes #21