### PR TITLE
Add Atom logo license details

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,11 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+MDAnalysis Logo 'Atom' by Christian Beckstein is licensed under a
+Creative Commons Attribution-NoDerivs 3.0 Unported License.
+To view a copy of this license, visit
+http://creativecommons.org/licenses/by-nd/3.0/ or send a letter to Creative
+Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.


### PR DESCRIPTION
Fixes #44 

I guess it depends on what we want to do here (vs just copying the license around with the logo, which might be easier downstream).