### PR TITLE
fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
-    python: "mambaforge-4.10"
+    python: "miniforge3-latest"
 
 python:
   install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ The rules for this file:
 ## [Unreleased]
 
 ### Authors
-IAlibay
+- IAlibay
+- orbeckst
 
 ### Reviewers
 <!-- GitHub usernames of reviewers of this release -->
@@ -31,6 +32,7 @@ IAlibay
 <!-- Bug fixes -->
 
 ### Changed
+- Bumped minimum required sphinx to 7.2.0 (#75, PR #100)
 - Modernized packaging to be PEP518 compliant.
 
 ### Removed

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pandoc
   - wheel
   - sphinx-autobuild
-  - sphinx>=6.2.1
+  - sphinx>=7.2.0
   - sphinx_rtd_theme
 
   - mdanalysis

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - nbconvert
   - ipykernel
   - autodoc-pydantic
-  - myst-parser~=1.0
+  - myst-parser
   - pandoc
   - wheel
   - sphinx-autobuild

--- a/docs/pydantic_example.py
+++ b/docs/pydantic_example.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field, validator
+from pydantic import Field, validator
+from pydantic_settings import BaseSettings
 
 
 class ExampleSettings(BaseSettings):
@@ -10,16 +11,9 @@ class ExampleSettings(BaseSettings):
     field_plain_with_validator: int = 100
     """Show standard field with type annotation."""
 
-    field_plain = 100
-    """Show standard field without type annotation."""
-
     field_with_validator_and_alias: str = Field("FooBar", alias="BarFoo", env="BarFoo")
     """Shows corresponding validator with link/anchor."""
 
-    field_with_validator_and_alias_typeless = Field(
-        "FooBar", alias="BarFoo", env="BarFoo"
-    )
-    """Shows corresponding validator with link/anchor but without type annotation."""
 
     field_with_constraints_and_description: int = Field(
         default=5, ge=0, le=100, description="Shows constraints within doc string."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"
 dependencies = [
     "sphinx_rtd_theme>=1.3",
-    "sphinx>=6.2.1",
+    "sphinx>=7.2.0",
     "beautifulsoup4",
     "python-slugify[unidecode]",
     "css_html_js_minify",


### PR DESCRIPTION
Fixes #99 and #75

Changes made in this Pull Request:
 - RTD config update
   - use os = ubuntu-lts-latest
   - use tools.python = "miniforge3-latest"  
 - bump sphinx to >= 7.2.0
   - required for making it work under Python 3.14 (otherwise error due ast.Str missing)
   - removed pin on myst-parser (required for sphinx>=7)
 - fixed the pydantic example (would not pass with pydantic > 1)

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
